### PR TITLE
libavfilter/vf_drawtext: add letter_spacing as an evaluated parameter

### DIFF
--- a/libavfilter/vf_drawtext.c
+++ b/libavfilter/vf_drawtext.c
@@ -816,7 +816,7 @@ static av_cold int init(AVFilterContext *ctx)
                        FT_STROKER_LINEJOIN_ROUND, 0);
     }
 
-    s->use_kerning = FT_HAS_KERNING(s->face);
+    s->use_kerning = FT_HAS_KERNING(s->face) && !s->letter_spacing;
 
     /* load the fallback glyph with code 0 */
     load_glyph(ctx, NULL, 0);
@@ -1537,7 +1537,7 @@ continue_on_invalid2:
         x += s->letter_spacing;
 
         /* kerning */
-        if (!s->letter_spacing && s->use_kerning && prev_glyph && glyph->code) {
+        if (s->use_kerning && prev_glyph && glyph->code) {
             FT_Get_Kerning(s->face, prev_glyph->code, glyph->code,
                            ft_kerning_default, &delta);
             x += delta.x >> 6;

--- a/libavfilter/vf_drawtext.c
+++ b/libavfilter/vf_drawtext.c
@@ -183,6 +183,7 @@ typedef struct DrawTextContext {
     unsigned int fontsize;          ///< font size to use
     unsigned int default_fontsize;  ///< default font size to use
 
+    int letter_spacing;             ///< letter spacing in pixels
     int line_spacing;               ///< lines spacing in pixels
     short int draw_box;             ///< draw box around text - true or false
     int boxborderw;                 ///< box border width
@@ -237,7 +238,8 @@ static const AVOption drawtext_options[]= {
     {"shadowcolor", "set shadow color",     OFFSET(shadowcolor.rgba),   AV_OPT_TYPE_COLOR,  {.str="black"}, 0, 0, FLAGS},
     {"box",         "set box",              OFFSET(draw_box),           AV_OPT_TYPE_BOOL,   {.i64=0},     0,        1       , FLAGS},
     {"boxborderw",  "set box border width", OFFSET(boxborderw),         AV_OPT_TYPE_INT,    {.i64=0},     INT_MIN,  INT_MAX , FLAGS},
-    {"line_spacing",  "set line spacing in pixels", OFFSET(line_spacing),   AV_OPT_TYPE_INT,    {.i64=0},     INT_MIN,  INT_MAX,FLAGS},
+    {"letter_spacing", "set letter spacing in pixels", OFFSET(letter_spacing), AV_OPT_TYPE_INT, {.i64=0}, INT_MIN,  INT_MAX, FLAGS},
+    {"line_spacing",  "set line spacing in pixels", OFFSET(line_spacing),      AV_OPT_TYPE_INT, {.i64=0}, INT_MIN,  INT_MAX, FLAGS},
     {"fontsize",    "set font size",        OFFSET(fontsize_expr),      AV_OPT_TYPE_STRING, {.str=NULL},  0, 0 , FLAGS},
     {"x",           "set x expression",     OFFSET(x_expr),             AV_OPT_TYPE_STRING, {.str="0"},   0, 0, FLAGS},
     {"y",           "set y expression",     OFFSET(y_expr),             AV_OPT_TYPE_STRING, {.str="0"},   0, 0, FLAGS},
@@ -1036,7 +1038,7 @@ static int func_pts(AVFilterContext *ctx, AVBPrint *bp,
 
 static int func_frame_num(AVFilterContext *ctx, AVBPrint *bp,
                           char *fct, unsigned argc, char **argv, int tag)
-{
+{   
     DrawTextContext *s = ctx->priv;
 
     av_bprintf(bp, "%d", (int)s->var_values[VAR_N]);
@@ -1532,6 +1534,9 @@ continue_on_invalid2:
             x += delta.x >> 6;
         }
 
+        /* letter spacing */
+        x += s->letter_spacing;
+
         /* save position */
         s->positions[i].x = x + glyph->bitmap_left;
         s->positions[i].y = y - glyph->bitmap_top + y_max;
@@ -1539,7 +1544,7 @@ continue_on_invalid2:
         else              x += glyph->advance;
     }
 
-    max_text_line_w = FFMAX(x, max_text_line_w);
+    max_text_line_w = FFMAX(x, max_text_line_w) + s->letter_spacing;
 
     s->var_values[VAR_TW] = s->var_values[VAR_TEXT_W] = max_text_line_w;
     s->var_values[VAR_TH] = s->var_values[VAR_TEXT_H] = y + s->max_glyph_h;

--- a/libavfilter/vf_drawtext.c
+++ b/libavfilter/vf_drawtext.c
@@ -183,6 +183,7 @@ typedef struct DrawTextContext {
     unsigned int fontsize;          ///< font size to use
     unsigned int default_fontsize;  ///< default font size to use
 
+    int letter_spacing;             ///< letter spacing in pixels
     int line_spacing;               ///< lines spacing in pixels
     short int draw_box;             ///< draw box around text - true or false
     int boxborderw;                 ///< box border width
@@ -210,7 +211,6 @@ typedef struct DrawTextContext {
     int alpha;
     char* letter_spacing_expr;      ///< expression for letter spacing
     AVExpr* letter_spacing_pexpr;   ///< parsed expression for letter spacing
-    int letter_spacing;             ///< letter spacing in pixels
     AVLFG  prng;                    ///< random
     char       *tc_opt_string;      ///< specified timecode option string
     AVRational  tc_rate;            ///< frame rate for timecode
@@ -1551,7 +1551,7 @@ continue_on_invalid2:
     }
 
     s->letter_spacing = av_expr_eval(s->letter_spacing_pexpr, s->var_values, &s->prng);
-    if (s->letter_spacing<0) {
+    if (s->letter_spacing < 0) {
         max_text_line_w = x+ s->letter_spacing;
     }
     else {

--- a/libavfilter/vf_drawtext.c
+++ b/libavfilter/vf_drawtext.c
@@ -1038,7 +1038,7 @@ static int func_pts(AVFilterContext *ctx, AVBPrint *bp,
 
 static int func_frame_num(AVFilterContext *ctx, AVBPrint *bp,
                           char *fct, unsigned argc, char **argv, int tag)
-{   
+{
     DrawTextContext *s = ctx->priv;
 
     av_bprintf(bp, "%d", (int)s->var_values[VAR_N]);

--- a/libavfilter/vf_drawtext.c
+++ b/libavfilter/vf_drawtext.c
@@ -241,7 +241,7 @@ static const AVOption drawtext_options[]= {
     {"box",         "set box",              OFFSET(draw_box),           AV_OPT_TYPE_BOOL,   {.i64=0},     0,        1       , FLAGS},
     {"boxborderw",  "set box border width", OFFSET(boxborderw),         AV_OPT_TYPE_INT,    {.i64=0},     INT_MIN,  INT_MAX , FLAGS},
     {"letter_spacing", "set letter spacing in pixels", OFFSET(letter_spacing_expr), AV_OPT_TYPE_STRING, {.str="0"}, 0, 0, FLAGS},
-    {"line_spacing",  "set line spacing in pixels", OFFSET(line_spacing),      AV_OPT_TYPE_INT, {.i64=0}, INT_MIN,  INT_MAX, FLAGS},
+    {"line_spacing",  "set line spacing in pixels", OFFSET(line_spacing),   AV_OPT_TYPE_INT,    {.i64=0},     INT_MIN,  INT_MAX,FLAGS},
     {"fontsize",    "set font size",        OFFSET(fontsize_expr),      AV_OPT_TYPE_STRING, {.str=NULL},  0, 0 , FLAGS},
     {"x",           "set x expression",     OFFSET(x_expr),             AV_OPT_TYPE_STRING, {.str="0"},   0, 0, FLAGS},
     {"y",           "set y expression",     OFFSET(y_expr),             AV_OPT_TYPE_STRING, {.str="0"},   0, 0, FLAGS},
@@ -1537,7 +1537,7 @@ continue_on_invalid2:
         x += s->letter_spacing;
 
         /* kerning */
-        if (s->letter_spacing == 0 && s->use_kerning && prev_glyph && glyph->code) {
+        if (!s->letter_spacing && s->use_kerning && prev_glyph && glyph->code) {
             FT_Get_Kerning(s->face, prev_glyph->code, glyph->code,
                            ft_kerning_default, &delta);
             x += delta.x >> 6;
@@ -1553,8 +1553,7 @@ continue_on_invalid2:
     s->letter_spacing = av_expr_eval(s->letter_spacing_pexpr, s->var_values, &s->prng);
     if (s->letter_spacing < 0) {
         max_text_line_w = x+ s->letter_spacing;
-    }
-    else {
+    } else {
         max_text_line_w = FFMAX(x, max_text_line_w) + s->letter_spacing;
     }
 


### PR DESCRIPTION
When enabled it will add pixels (or subtract if given a negative value) between each letters, 
set use_kerning to false,
and add the pixels to text_w

Signed-off-by: Mark Ren <mark.ren77@gmail.com>